### PR TITLE
Update P835 module to version 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+This file contains the changelog for the ItuRPropagation package. It follows the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format.
+
+## Unreleased
+
+### Changed
+- The code for the `IturP835` module has been updated to follow version 7 of the ITU-R P.835 recommendation.
+  - The `standardwatervapordensity` function now only accepts the geometric height `Z` as sole positional argument. It is still accepting specific values of `ρ₀` (also as `rho_0`), `T`, and `P` as keyword arguments but they all have default values as per equations 6-8 in Section 1.2 of the recommendation.

--- a/Project.toml
+++ b/Project.toml
@@ -2,11 +2,11 @@ name = "ItuRPropagation"
 uuid = "a73e506c-35e8-47b2-857c-dfce7ead1349"
 authors = ["Hillary Kchao <hillary.kchao@gmail.com>", "Alberto Mengali <disberd@gmail.com>"]
 repo = "https://github.com/disberd/ItuRPropagation.jl"
-version = "0.2.0-DEV"
+version = "0.3.0-DEV"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 
 [compat]
-julia = "1.8.2"
+julia = "1.10"
 Artifacts = "1"

--- a/src/iturP1511.jl
+++ b/src/iturP1511.jl
@@ -5,7 +5,7 @@ This Recommendation provides global topographical data, information on geographi
 height data for the prediction of propagation effects for Earth-space paths in ITU-R recommendations.
 =#
 
-using ItuRPropagation
+using ..ItuRPropagation
 using Artifacts
 const version = ItuRVersion("ITU-R", "P.1511", 2, "(08/2019)")
 

--- a/src/iturP2145.jl
+++ b/src/iturP2145.jl
@@ -6,7 +6,7 @@ temperature, surface water vapour density and integrated water vapour content re
 gaseous attenuation and related effects on terrestrial and Earth-space paths.
 =#
 
-using ItuRPropagation
+using ..ItuRPropagation
 using Artifacts
 
 const version = ItuRVersion("ITU-R", "P.2145", 0, "(08/2022)")

--- a/src/iturP372.jl
+++ b/src/iturP372.jl
@@ -7,7 +7,7 @@ the Earth’s surface, the galaxy, and man-made sources. Noise figures or temper
 basis for the estimation of system performance.
 =#
 
-using ItuRPropagation
+using ..ItuRPropagation
 using Artifacts
 
 const version = ItuRVersion("ITU-R", "P.372", 16, "(08/2022)")

--- a/src/iturP453.jl
+++ b/src/iturP453.jl
@@ -7,7 +7,7 @@ Recommendation ITU-R P.453 provides methods to estimate the radio refractive ind
  parameters and their statistical variation.
 =#
 
-using ItuRPropagation
+using ..ItuRPropagation
 using Artifacts
 const version = ItuRVersion("ITU-R", "P.453", 14, "(08/2019)")
 

--- a/src/iturP618.jl
+++ b/src/iturP618.jl
@@ -5,8 +5,8 @@ This Recommendation predicts the various propagation parameters needed in planni
 systems operating in either the Earth-to-space or space-to-Earth direction.
 =#
 
-using ItuRPropagation
-using ItuRPropagation: tilt_from_polarization
+using ..ItuRPropagation
+using ..ItuRPropagation: tilt_from_polarization
 using Artifacts
 
 const version = ItuRVersion("ITU-R", "P.618", 14, "(08/2023)")

--- a/src/iturP676.jl
+++ b/src/iturP676.jl
@@ -18,7 +18,7 @@ d) a Weibull approximation to the slant path water vapour attenuation for use in
     Recommendation ITU-R P.1853.
 =#
 
-using ItuRPropagation
+using ..ItuRPropagation
 using Artifacts
 const version = ItuRVersion("ITU-R", "P.676", 13, "(08/2022)")
 

--- a/src/iturP676.jl
+++ b/src/iturP676.jl
@@ -319,7 +319,9 @@ function gaseousattenuation(
     hs::Union{Real,Missing}=missing
 )
     ρ₀ = ItuRP2145.surfacewatervapordensityannual(latlon, p, hs)     # equation 62 of ItuRP618
-    ρᵢ = ItuRP835.standardwatervapordensity(hᵢ, Tᵢ, Pᵢ, ρ₀)
+    ρᵢ = map(zip(hᵢ, Tᵢ, Pᵢ)) do (Z, T, P)
+        ItuRP835.standardwatervapordensity(Z; T, P, ρ₀)
+    end
     eᵢ = (Tᵢ .* ρᵢ) ./ (216.7)     # equation 4
     dryPᵢ = Pᵢ - eᵢ     # must be changed to dry air pressure
 

--- a/src/iturP835.jl
+++ b/src/iturP835.jl
@@ -5,7 +5,7 @@ Recommendation ITU-R P.835 provides expressions and data for reference standard 
 the calculation of gaseous attenuation on Earth-space paths.
 =#
 
-using ItuRPropagation
+using ..ItuRPropagation
 using Artifacts
 
 const version = ItuRVersion("ITU-R", "P.835", 16, "(12/2017)")
@@ -109,24 +109,30 @@ function standardwatervapordensity(
     P::Array{Float64}, 
     ρ₀::Float64=7.5
 )
-    N = length(h)
-    ρvalues = zeros(Float64, N)
-    for i in 1:N
-        # equation 6 where h₀ = 2; equation 7 where ρ₀=7.5
-        ρ = ρ₀ * exp(-h[i] / 2.0)
-
-        # see paragraph below equation 8 regarding mixing ratio
-        e = ρ * T[i] / 216.7
-        mixingratio = e / P[i]
-        if mixingratio < 2e-6
-            # see paragraph below equation 8 regarding mixing ratio
-            # and recalculate ρ
-            enew = P[i] * 2e-6
-            ρ = enew * 216.7 / T[i]
-        end
-        ρvalues[i] = ρ
+    map(h, T, P) do h, T, P
+        standardwatervapordensity(h, T, P, ρ₀)
     end
-    return ρvalues
+end
+
+function standardwatervapordensity(
+    h::Real, 
+    T::Real, 
+    P::Real, 
+    ρ₀::Real=7.5
+)
+    # equation 6 where h₀ = 2; equation 7 where ρ₀=7.5
+    ρ = ρ₀ * exp(-h / 2.0)
+
+    # see paragraph below equation 8 regarding mixing ratio
+    e = ρ * T / 216.7
+    mixingratio = e / P
+    if mixingratio < 2e-6
+        # see paragraph below equation 8 regarding mixing ratio
+        # and recalculate ρ
+        enew = P * 2e-6
+        ρ = enew * 216.7 / T
+    end
+    return ρ
 end
 
 end # module ItuRP835

--- a/src/iturP835.jl
+++ b/src/iturP835.jl
@@ -8,23 +8,26 @@ the calculation of gaseous attenuation on Earth-space paths.
 using ..ItuRPropagation
 using Artifacts
 
-const version = ItuRVersion("ITU-R", "P.835", 16, "(12/2017)")
+const version = ItuRVersion("ITU-R", "P.835", 7, "(08/2024)")
+
+# Geometric height to geopotential height
+geopotentialheight(z::Real) = z * 6356.766 / (z + 6356.766)
 
 """
-    standardtemperature(h::Float64)
+    standardtemperature(Z::Float64)
 
 Standard temperature for geometric heights <= 100 km, based on equations 2a-2g and 4a-4b of Section 1.1
 
 # Arguments
-- `h::Float64`: geometric height (km)
+- `Z::Float64`: geometric height (km)
 
 # Return
 - temperature (°K)
 """
-function standardtemperature(h::Float64)
-    (h < 0.0 || h > 100.0) && throw(ArgumentError("h=$h\n (geometric height) in IturP835.standardtemperature must be between 0 and 100"))
+function standardtemperature(Z::Real)
+    0 ≤ Z ≤ 100 || throw(ArgumentError("Z=$Z\n (geometric height) in IturP835.standardtemperature must be between 0 and 100"))
 
-    hp = (h * 6356.766) / (h + 6356.766)
+    hp = geopotentialheight(Z)
     if 0 <= hp <= 11
         return (288.15 - 6.5 * hp)
     elseif 11 < hp <= 20
@@ -39,28 +42,28 @@ function standardtemperature(h::Float64)
         return (270.65 - 2.8 * (hp - 51))
     elseif 71 < hp <= 84.852
         return (214.65 - 2(hp - 71))
-    elseif 86 <= h <= 91
+    elseif 86 <= Z <= 91
         return 186.8673
-    elseif 91 < h <= 100
-        return (263.1905 - 76.3232 * sqrt(1 - ((h - 91) / 19.9429)^2))
+    elseif 91 < Z <= 100
+        return (263.1905 - 76.3232 * sqrt(1 - ((Z - 91) / 19.9429)^2))
     end
 end
 
 
 """
-    standardpressure(h::Float64)
+    standardpressure(Z::Float64)
 
 Standard pressure for geometric heights <= 100 km, based on equations 3a-3g and 5 of Section 1.1.
 
 # Arguments
-- `h::Float64`: geometric height (km)
+- `Z::Float64`: geometric height (km)
 
 # Return
 - dry pressure (hPa)
 """
-function standardpressure(h::Float64)
-    (h < 0.0 || h > 100.0) && throw(ArgumentError("h=$h\n (geometric height) in IturP835.standardpressure must be between 0 and 100"))
-    hp = (h * 6356.766) / (h + 6356.766)
+function standardpressure(Z::Real)
+    0 ≤ Z ≤ 100 || throw(ArgumentError("Z=$Z\n (geometric height) in IturP835.standardpressure must be between 0 and 100"))
+    hp = geopotentialheight(Z)
     if 0 <= hp <= 11
         return (1013.25 * (288.15 / (288.15 - 6.5 * hp))^(-34.1632 / 6.5))
     elseif 11 < hp <= 20
@@ -75,53 +78,40 @@ function standardpressure(h::Float64)
         return (0.6694167 * (270.65 / (270.65 - 2.8 * (hp - 51)))^(-34.1632 / 2.8))
     elseif 71 < hp <= 84.852
         return (0.03956649 * (214.65 / (214.65 - 2.0 * (hp - 71)))^(-34.1632 / 2.0))
-    elseif 86 <= h <= 100
-        return exp(95.571899
-                   -
-                   4.011801 * hp
-                   +
-                   6.424731e-2 * hp^2
-                   -
-                   4.789660e-4 * hp^3
-                   +
-                   1.340543e-6 * hp^4)
+    elseif 86 <= Z <= 100
+        a₀ = 95.571899
+        a₁ = -4.011801
+        a₂ = 6.424731e-2
+        a₃ = -4.789660e-4
+        a₄ = 1.340543e-6
+        return exp(a₀ + a₁ * Z + a₂ * Z^2 + a₃ * Z^3 + a₄ * Z^4)
     end
 end
 
 
 """
-    standardwatervapordensity(h::Array{Float64}, T::Array{Float64}, P::Array{Float64}, ρ₀::Float64=7.5)
+    standardwatervapordensity(Z; kwargs...)
 
-Standard pressure for geometric heights <= 100 km based on Section 1.2.
+Standard water vapor density for geometric heights <= 100 km, based on equations 6-8 of Section 1.2.
 
 # Arguments
-- `h::Array{Float64}`: array of geometric heights (km)
-- `T::Array{Float64}`: array of temperatures (°K)
-- `P::Array{Float64}`: array of pressures (hPa)
-- `ρ₀::Float64=7.5`: standard ground level water vapor density (g/m^3)
+- `Z::Real`: geometric height (km)
 
-# Return
-- standard water vapor density (g/m^3)
+# Keyword arguments
+- `rho_0::Real=7.5`: standard ground level water vapor density (g/m^3). Can also be provided as `ρ₀`.
+- `T::Real`: Temperature (°K) at given height. Computed with `standardtemperature(Z)` if not provided.
+- `P::Real`: Total barometric pressure (hPa) at given height. Computed with `standardpressure(Z)` if not provided.
 """
 function standardwatervapordensity(
-    h::Array{Float64}, 
-    T::Array{Float64}, 
-    P::Array{Float64}, 
-    ρ₀::Float64=7.5
+        Z::Real; 
+        rho_0 = nothing,
+        ρ₀ = nothing,
+        T = standardtemperature(Z),
+        P = standardpressure(Z),
 )
-    map(h, T, P) do h, T, P
-        standardwatervapordensity(h, T, P, ρ₀)
-    end
-end
-
-function standardwatervapordensity(
-    h::Real, 
-    T::Real, 
-    P::Real, 
-    ρ₀::Real=7.5
-)
+    ρ₀ = @something ρ₀ rho_0 7.5
     # equation 6 where h₀ = 2; equation 7 where ρ₀=7.5
-    ρ = ρ₀ * exp(-h / 2.0)
+    ρ = ρ₀ * exp(-Z / 2)
 
     # see paragraph below equation 8 regarding mixing ratio
     e = ρ * T / 216.7

--- a/src/iturP837.jl
+++ b/src/iturP837.jl
@@ -15,7 +15,7 @@ When reliable long-term local rainfall rate data is available with integration t
  times that exceed 1-min to rainfall rate statistics with a 1-min integration time.
 =#
 
-using ItuRPropagation
+using ..ItuRPropagation
 using Artifacts
 
 const version = ItuRVersion("ITU-R", "P.837", 7, "(06/2017)")

--- a/src/iturP838.jl
+++ b/src/iturP838.jl
@@ -5,8 +5,8 @@ Recommendation ITU-R P.838-3 recommends the procedure for obtaining the
  specfic attenuation (gamma sub R in dB/km) from the rain rate R (mm/h).
 =#
 
-using ItuRPropagation
-using ItuRPropagation: tilt_from_polarization
+using ..ItuRPropagation
+using ..ItuRPropagation: tilt_from_polarization
 using Artifacts
 
 const version = ItuRVersion("ITU-R", "P.838", 8, "03/2005")

--- a/src/iturP839.jl
+++ b/src/iturP839.jl
@@ -4,7 +4,7 @@ module ItuRP839
 This Recommendation provides a method to predict the rain height for propagation prediction.
 =#
 
-using ItuRPropagation
+using ..ItuRPropagation
 using Artifacts
 const version = ItuRVersion("ITU-R", "P.839", 4, "(09/2013)")
 

--- a/src/iturP840.jl
+++ b/src/iturP840.jl
@@ -4,7 +4,7 @@ module ItuRP840
 This Recommendation provides methods to predict the attenuation due to clouds and fog on Earth-space paths.
 =#
 
-using ItuRPropagation
+using ..ItuRPropagation
 using Artifacts
 
 const version = ItuRVersion("ITU-R", "P.840", 8, "(08/2019)")


### PR DESCRIPTION
This PR has no real functional change, as version 7 equations are somehow equivalent to the ones of the previous version

It mainly changed the signature of the standardwatervapordensity to only accepts a single positional argument (the geometric height Z) and leave all other optional parameters as keyword arguments