### PR TITLE
P839 refactor with tests from excel

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -26,19 +26,19 @@ git-tree-sha1 = "f3d58fae18a5660786f5c10d0a51f3c1e9bd5ff1"
     sha256 = "bfa0ae57a8e33316d1b473fb0fa0aff2d4c5b229c6f7808e666aecfe1ea80122"
     url = "https://github.com/JuliaSatcomFramework/ItuRPropagation.jl/releases/download/artifact_releases/p453_nwet_annual.tar.gz"
 
-[p839]
-git-tree-sha1 = "bb37711b3401b9462872241e4b9e17059827b513"
-
-    [[p839.download]]
-    sha256 = "9d81e0bdd35311a81669e9682a4826a64d0d77820978ce13796506ed6b69443e"
-    url = "https://github.com/JuliaSatcomFramework/ItuRPropagation.jl/releases/download/artifact_releases/p839.tar.gz"
-
 [p676]
 git-tree-sha1 = "a21d87acc281d70dc82ff050ad23a39e60af962b"
 
     [[p676.download]]
     sha256 = "b8e9de886d893deb902d6bd4f137d18bc74cadaa1587af61a573b0947d5ff85d"
     url = "https://github.com/JuliaSatcomFramework/ItuRPropagation.jl/releases/download/artifact_releases/p676_data.tar.gz"
+
+[p839]
+git-tree-sha1 = "2f4c1f82dc8fd5affa973a0dd272555b65c8f1eb"
+
+    [[p839.download]]
+    sha256 = "c90a691aa7174171fd5707fa908a9db7a3d80d00dea39fba579fc299d33a846d"
+    url = "https://github.com/JuliaSatcomFramework/ItuRPropagation.jl/releases/download/artifact_releases/p839.tar.gz"
 
 [p840_annual]
 git-tree-sha1 = "4c0426c8ad13e4007c2f63312b77356d0608d2ef"

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -26,6 +26,13 @@ git-tree-sha1 = "f3d58fae18a5660786f5c10d0a51f3c1e9bd5ff1"
     sha256 = "bfa0ae57a8e33316d1b473fb0fa0aff2d4c5b229c6f7808e666aecfe1ea80122"
     url = "https://github.com/JuliaSatcomFramework/ItuRPropagation.jl/releases/download/artifact_releases/p453_nwet_annual.tar.gz"
 
+[p839]
+git-tree-sha1 = "bb37711b3401b9462872241e4b9e17059827b513"
+
+    [[p839.download]]
+    sha256 = "9d81e0bdd35311a81669e9682a4826a64d0d77820978ce13796506ed6b69443e"
+    url = "https://github.com/JuliaSatcomFramework/ItuRPropagation.jl/releases/download/artifact_releases/p839.tar.gz"
+
 [p676]
 git-tree-sha1 = "a21d87acc281d70dc82ff050ad23a39e60af962b"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Note that basically all changes above are **BREAKING**
 - The implementation of cloud attenuation in module `ItuRP840` has been refactored, now relying on artifacts and on convenience interpolation structures in `ItuRP1144`
 - The `ItuRP840.cloudattenuation` now has a different signature, with the elevation and exceedance probability swapped to e more consistent with the recent changes to other module.
 - Refactored the `ItuRP453` module to use independent artifacts and now provide a function to interpolate the wetterm refractive index not only at the 50 percentile
+- Refactored the `ItuRP839` module to use specific artifacts and its test to use the ITU validation excel version 8.3
 
 ### Added
 - A new `ItuRP1144` module has been added to hold the interpolation functions defined recommendation ITU-R P.1144-12.

--- a/src/iturP1511.jl
+++ b/src/iturP1511.jl
@@ -9,6 +9,12 @@ using ..ItuRPropagation
 using Artifacts
 const version = ItuRVersion("ITU-R", "P.1511", 3, "(08/2023)")
 
+# Exports and constructor with separate latitude and longitude arguments
+for name in (:topographicheight,)
+    @eval $name(lat::Number, lon::Number, args...; kwargs...) = $name(LatLon(lat, lon), args...; kwargs...)
+    @eval export $name
+end
+
 #region initialization
 
 const GRID_DATA = (;
@@ -32,7 +38,7 @@ const GRID_DATA = (;
 
 """
     topographicheight(latlon::LatLon)
-    topographicheight(lat::Float64, lon::Float64)
+    topographicheight(lat, lon)
 
 Calculates topographic height as per Section 1.1 of ITU-R P.1511-3.
 
@@ -42,7 +48,6 @@ Calculates topographic height as per Section 1.1 of ITU-R P.1511-3.
 # Return
 - `I::Real`: height (km)
 """
-topographicheight(lat, lon) = topographicheight(LatLon(lat, lon))
 function topographicheight(latlon::LatLon)
     grid_data = GRID_DATA.topo
     alt = ItuRP1144.bicubic_interpolation(grid_data.data, latlon, grid_data.latrange, grid_data.lonrange) / 1e3

--- a/src/iturP2145.jl
+++ b/src/iturP2145.jl
@@ -9,7 +9,11 @@ gaseous attenuation and related effects on terrestrial and Earth-space paths.
 using ..ItuRPropagation: ItuRPropagation, LatLon, ItuRVersion, ItuRP1511, ItuRP1144, _tolatlon, _tokm, SUPPRESS_WARNINGS
 using Artifacts: Artifacts, @artifact_str
 
-export surfacetemperatureannual, surfacewatervapourdensityannual, surfacepressureannual, surfacewatervapourcontentannual
+# Exports and constructor with separate latitude and longitude arguments
+for name in (:surfacetemperatureannual, :surfacewatervapourdensityannual, :surfacepressureannual, :surfacewatervapourcontentannual)
+    @eval $name(lat::Number, lon::Number, args...; kwargs...) = $name(LatLon(lat, lon), args...; kwargs...)
+    @eval export $name
+end
 
 const version = ItuRVersion("ITU-R", "P.2145", 0, "(08/2022)")
 
@@ -290,8 +294,5 @@ function _annual_surface_values(latlon, args...; alt = nothing)
     ρ = surfacewatervapourdensityannual(latlon, args...; alt)
     return (; P, T, ρ, alt)
 end
-
-
-
 
 end # module ItuRP2145

--- a/src/iturP372.jl
+++ b/src/iturP372.jl
@@ -43,7 +43,7 @@ the receiver to the spacecraft transmitter.
 - `Tsky::Real`: sky noise temperature at a ground station antenna (°K)
 """
 function earthstationnoisetemperature(
-    latlon::LatLon,
+    latlon,
     p::Real,
     A::Real
 )

--- a/src/iturP453.jl
+++ b/src/iturP453.jl
@@ -218,7 +218,7 @@ Interpolates wet term of the surface refractivity at an exceedance probability `
 # Return
 - `Nwet::Real`: wet term of the surface refractivity (ppm)
 """
-function wettermsurfacerefractivityannual(latlon, p::Real; warn=!SUPPRESS_WARNINGS[])
+function wettermsurfacerefractivityannual(latlon, p; warn=!SUPPRESS_WARNINGS[])
     itp = @something(NWET_ANNUAL.ccdf,let
         initialize!()
         NWET_ANNUAL.ccdf

--- a/src/iturP453.jl
+++ b/src/iturP453.jl
@@ -12,6 +12,12 @@ using ..ItuRP1144: ItuRP1144, AbstractSquareGridITP, SquareGridData, SquareGridS
 using Artifacts
 const version = ItuRVersion("ITU-R", "P.453", 14, "(08/2019)")
 
+# Exports and constructor with separate latitude and longitude arguments
+for name in (:wettermsurfacerefractivityannual, :wettermsurfacerefractivityannual_50)
+    @eval $name(lat::Number, lon::Number, args...; kwargs...) = $name(LatLon(lat, lon), args...; kwargs...)
+    @eval export $name
+end
+
 #region initialization
 
 const δlat = 0.75

--- a/src/iturP676.jl
+++ b/src/iturP676.jl
@@ -24,7 +24,11 @@ using ..ItuRPropagation: _torad, ItuRP835, ItuRP453, ItuRVersion, ItuRP1511, Lat
 using Artifacts
 const version = ItuRVersion("ITU-R", "P.676", 13, "(08/2022)")
 
-export gaseousattenuation
+# Exports and constructor with separate latitude and longitude arguments
+for name in (:gaseousattenuation,)
+    @eval $name(lat::Number, lon::Number, args...; kwargs...) = $name(LatLon(lat, lon), args...; kwargs...)
+    @eval export $name
+end
 
 #region coefficients
 

--- a/src/iturP839.jl
+++ b/src/iturP839.jl
@@ -9,6 +9,12 @@ using ..ItuRP1144: ItuRP1144, AbstractSquareGridITP, SquareGridData, SquareGridS
 using Artifacts
 const version = ItuRVersion("ITU-R", "P.839", 4, "(09/2013)")
 
+# Exports and constructor with separate latitude and longitude arguments
+for name in (:isothermheight, :rainheightannual)
+    @eval $name(lat::Number, lon::Number, args...; kwargs...) = $name(LatLon(lat, lon), args...; kwargs...)
+    @eval export $name
+end
+
 #region initialization
 
 const δlat = 1.5

--- a/src/iturP839.jl
+++ b/src/iturP839.jl
@@ -4,49 +4,37 @@ module ItuRP839
 This Recommendation provides a method to predict the rain height for propagation prediction.
 =#
 
-using ..ItuRPropagation
+using ..ItuRPropagation: ItuRPropagation, LatLon, ItuRVersion, _tolatlon, _tokm, _torad, _toghz, SUPPRESS_WARNINGS
+using ..ItuRP1144: ItuRP1144, AbstractSquareGridITP, SquareGridData, SquareGridStatisticalData
 using Artifacts
 const version = ItuRVersion("ITU-R", "P.839", 4, "(09/2013)")
 
 #region initialization
 
-const latsize = 121 + 1 # number of latitude points (-90, 90, 0.75) plus one extra row for interpolation
-const lonsize = 241 + 1 # number of longitude points (-180, 180, 0.75) plus one extra column for interpolation
+const δlat = 1.5
+const δlon = 1.5
+const latrange = range(-90, 90, step=δlat)
+const lonrange = range(-180, 180, step=δlon)
+const datasize = (length(latrange), length(lonrange))
 
-const latvalues = [(-90.0 + (i - 1) * 1.5) for i in 1:latsize]
-const lonvalues = [(-180.0 + (j - 1) * 1.5) for j in 1:lonsize]
-
-const initialized = Ref{Bool}(false)
-
-const isothermheightdata = zeros(Float64, latsize, lonsize)
-
-function initialize()
-    initialized[] && return nothing
-    read!(
-        joinpath(artifact"input-maps", "isothermheighth0annual_$(string(latsize))_x_$(string(lonsize)).bin"),
-        isothermheightdata
-    )
-    initialized[] = true
-    return nothing
-end
+const H0_DATA = SquareGridData(latrange, lonrange, read!(joinpath(artifact"p839", "h0.bin"), zeros(datasize)), "Isotherm height")
 
 #endregion initialization
 
 """
     rainheightannual(latlon::LatLon)
-    rainheightannual(lat::Real, lon::Real)
 
 Computes rain height based on the equation in Section 2.
 h0 will be interpolated for the given latitude and longitude.
 
 # Arguments
-- `latlon::LatLon`: latitude and longitude (degrees)
+- `latlon`: object representing latitude and longitude, must be convertible to `ItuRPropagation.LatLon`
 
 # Return
-- `hR::Real`: mean annual rain height above mean sea level
+- `hR`: mean annual rain height (km) above mean sea level
 """
-function rainheightannual(args...)
-    h0 = isothermheight(args...)
+function rainheightannual(latlon)
+    h0 = isothermheight(latlon)
 
     hR = h0 + 0.36  # equation in section 2
     return hR
@@ -54,37 +42,20 @@ end
 
 
 """
-    isothermheight(latlon::LatLon)
-    isothermheight(lat::Real, lon::Real)
+    isothermheight(latlon)
 
 Calculates isothermic height based on bilinear interpolation.
 h0 will be interpolated for the given latitude and longitude.
 
 # Arguments
-- `latlon::LatLon`: latitude and longitude (degrees)
+- `latlon`: object representing latitude and longitude, must be convertible to `ItuRPropagation.LatLon`
 
 # Return
-- `h0::Real`: mean annual 0°C isotherm height above mean sea level
+- `h0`: mean annual 0°C isotherm height (km) above mean sea level
 """
-isothermheight(latlon::LatLon) = isothermheight(latlon.lat, latlon.lon)
-function isothermheight(lat, lon)
-    initialize()
-    latrange = searchsorted(latvalues, lat)
-    lonrange = searchsorted(lonvalues, lon)
-    R = latrange.stop
-    C = lonrange.stop
-
-    r = ((lat + 90) / 1.5) + 1
-    c = ((lon + 180) / 1.5) + 1
-
-    h0 = (
-        isothermheightdata[R, C] * ((R + 1 - r) * (C + 1 - c)) +
-        isothermheightdata[R+1, C] * ((r - R) * (C + 1 - c)) +
-        isothermheightdata[R, C+1] * ((R + 1 - r) * (c - C)) +
-        isothermheightdata[R+1, C+1] * ((r - R) * (c - C))
-    )
-
-    return h0
+function isothermheight(latlon)
+    latlon = _tolatlon(latlon)
+    return H0_DATA(latlon)
 end
 
 end # module ItuRP839

--- a/src/iturP840.jl
+++ b/src/iturP840.jl
@@ -10,6 +10,12 @@ using Artifacts: Artifacts, @artifact_str
 
 const version = ItuRVersion("ITU-R", "P.840", 9, "(08/2023)")
 
+# Exports and constructor with separate latitude and longitude arguments
+for name in (:liquidwatercontent, :cloudattenuation)
+    @eval $name(lat::Number, lon::Number, args...; kwargs...) = $name(LatLon(lat, lon), args...; kwargs...)
+    @eval export $name
+end
+
 #region initialization
 
 const δlat = 0.25

--- a/test/iturP839test.jl
+++ b/test/iturP839test.jl
@@ -1,97 +1,17 @@
-using DelimitedFiles
-using Test
-using ItuRPropagation
-
-struct TestData
-    testinput
-    answer
+@testitem "P.839-4 - Rain Height Model" setup = [setup_common] begin
+    entries = XLSX.openxlsx(validation_file) do wb
+        sheet = XLSX.getsheet(wb, "P.839-4 Rain_Height")
+        map(eachrow(sheet["C22:G29"])) do row
+            (;
+                ll=LatLon(row[1], row[2]),
+                h0=row[4],
+                hR=row[5],
+            )
+        end
+    end
+    for entry in entries
+        (; ll, h0, hR) = entry
+        @test ItuRP839.isothermheight(ll) ≈ h0 rtol = error_tolerance
+        @test ItuRP839.rainheightannual(ll) ≈ hR rtol = error_tolerance
+    end
 end
-
-function testItuRP839()
-    allowableerror = 1.0e-10
-
-    randomdata = [
-        TestData((LatLon(-11.625000, -0.375000)), 4.578375000),
-        TestData((LatLon(-11.625000, -121.875000)), 4.822250000),
-        TestData((LatLon(31.875000, 53.625000)), 4.080875000),
-        TestData((LatLon(-56.625000, -108.375000)), 0.478062500),
-        TestData((LatLon(-61.125000, -156.375000)), 0.599687500),
-        TestData((LatLon(6.375000, 175.125000)), 4.794750000),
-        TestData((LatLon(61.875000, -99.375000)), 2.584437500),
-        TestData((LatLon(-50.625000, -54.375000)), 1.117625000),
-        TestData((LatLon(70.875000, -9.375000)), 0.725000000),
-        TestData((LatLon(-23.625000, 65.625000)), 4.131875000),
-        TestData((LatLon(63.375000, -169.875000)), 0.733875000),
-        TestData((LatLon(52.875000, -114.375000)), 2.827875000),
-        TestData((LatLon(82.875000, -91.875000)), 1.929187500),
-        TestData((LatLon(78.375000, -150.375000)), 2.375187500),
-        TestData((LatLon(36.375000, 106.125000)), 4.097562500),
-        TestData((LatLon(52.875000, -51.375000)), 2.504750000),
-        TestData((LatLon(-82.125000, 8.625000)), 3.088375000),
-        TestData((LatLon(1.875000, 52.125000)), 4.575812500),
-        TestData((LatLon(6.375000, -126.375000)), 4.718562500),
-        TestData((LatLon(81.375000, 97.125000)), 1.631437500),
-        TestData((LatLon(-37.125000, -22.875000)), 2.310125000),
-        TestData((LatLon(12.375000, -160.875000)), 4.735187500),
-        TestData((LatLon(-38.625000, 167.625000)), 2.284250000),
-        TestData((LatLon(-14.625000, 73.125000)), 4.673875000),
-        TestData((LatLon(-4.125000, -174.375000)), 4.801000000),
-        TestData((LatLon(49.875000, 155.625000)), 1.420312500),
-        TestData((LatLon(85.875000, 53.625000)), 2.088312500),
-        TestData((LatLon(60.375000, 85.125000)), 2.369312500),
-        TestData((LatLon(-5.625000, 50.625000)), 4.629437500),
-        TestData((LatLon(46.875000, 19.125000)), 2.749250000),]
-    println(" ")
-    errors = []
-    @testset "iturP839 (Itu-R P.839-4) isotherm height: random test" begin
-        for testdata in randomdata
-            error = abs(ItuRP839.isothermheight(testdata.testinput) - (testdata.answer))
-            push!(errors, error)
-            @test error < allowableerror
-        end
-    end
-    println("MAX ERROR: $(maximum(errors))\n")
-
-    ituisothermdata = [
-        TestData((LatLon(3.133, 101.70)), 4.59797440000),
-        TestData((LatLon(22.900, -43.23)), 3.79877866667),
-        TestData((LatLon(23.000, 30.00)), 4.16800000000),
-        TestData((LatLon(25.780, -80.22)), 4.20946133333),
-        TestData((LatLon(28.717, 77.30)), 4.89820404444),
-        TestData((LatLon(33.940, 18.43)), 2.20330275556),
-        TestData((LatLon(41.900, 12.49)), 2.68749333333),
-        TestData((LatLon(51.500, -0.14)), 2.09273333333),
-    ]
-    errors = []
-    @testset "iturP839 (Itu-R P.839-4) isotherm height: itu data test" begin
-        for testdata in ituisothermdata
-            error = abs(ItuRP839.isothermheight(testdata.testinput) - (testdata.answer))
-            push!(errors, error)
-            @test error < allowableerror
-        end
-    end
-    println("MAX ERROR: $(maximum(errors))\n")
-
-    iturainheightdata = [
-        TestData((LatLon(3.133, 101.70)), 4.95797440000),
-        TestData((LatLon(22.900, -43.23)), 4.15877866667),
-        TestData((LatLon(23.000, 30.00)), 4.52800000000),
-        TestData((LatLon(25.780, -80.22)), 4.56946133333),
-        TestData((LatLon(28.717, 77.30)), 5.25820404444),
-        TestData((LatLon(33.940, 18.43)), 2.56330275556),
-        TestData((LatLon(41.900, 12.49)), 3.04749333333),
-        TestData((LatLon(51.500, -0.14)), 2.45273333333),]
-    errors = []
-    @testset "iturP839 (Itu-R P.839-4) rain height: itu data test" begin
-        for testdata in iturainheightdata
-            error = abs(ItuRP839.rainheightannual(testdata.testinput) - (testdata.answer))
-            push!(errors, error)
-            @test error < allowableerror
-        end
-    end
-    println("MAX ERROR: $(maximum(errors))\n")
-end
-
-println("\n<===== " * "ITUR P839.4 "^5 * " =====")
-testItuRP839()
-println("===== " * "ITUR P839.4 "^5 * "=====> \n")

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -28,3 +28,47 @@
         ItuRPropagation.SUPPRESS_WARNINGS[] = false
     end
 end
+
+@testitem "Separat Lat, Lon arguments" begin
+    function randll()
+        lat, lon = rand() * 180 - 90, rand() * 360 - 180
+        lls = (lat, lon)
+        ll = LatLon(lat, lon)
+        return lls, ll
+    end
+    lls, ll = randll()
+    p = rand() * 50 + 10
+    f = 28
+    el = 20
+
+    ###### P453 ######
+    @test ItuRP453.wettermsurfacerefractivityannual(lls..., p) == ItuRP453.wettermsurfacerefractivityannual(ll, p)
+    @test ItuRP453.wettermsurfacerefractivityannual_50(lls...) == ItuRP453.wettermsurfacerefractivityannual_50(ll)
+
+    ###### P676 ######
+    @test ItuRP676.gaseousattenuation(lls..., f, el, p) == ItuRP676.gaseousattenuation(ll, f, el, p)
+
+    ###### P839 ######
+    @test ItuRP839.isothermheight(lls...) == ItuRP839.isothermheight(ll)
+    @test ItuRP839.rainheightannual(lls...) == ItuRP839.rainheightannual(ll)
+
+    ###### P840 ######
+    @test ItuRP840.liquidwatercontent(lls..., p) == ItuRP840.liquidwatercontent(ll, p)
+    @test ItuRP840.cloudattenuation(lls..., f, el, p) == ItuRP840.cloudattenuation(ll, f, el, p)
+
+    ###### P1511 ######
+    @test ItuRP1511.topographicheight(lls...) == ItuRP1511.topographicheight(ll)
+
+    ###### P2145 ######
+    ## Mean values
+    @test ItuRP2145.surfacetemperatureannual(lls...) == ItuRP2145.surfacetemperatureannual(ll)
+    @test ItuRP2145.surfacewatervapourdensityannual(lls...) == ItuRP2145.surfacewatervapourdensityannual(ll)
+    @test ItuRP2145.surfacepressureannual(lls...) == ItuRP2145.surfacepressureannual(ll)
+    @test ItuRP2145.surfacewatervapourcontentannual(lls...) == ItuRP2145.surfacewatervapourcontentannual(ll)
+
+    ## CCDF Values
+    @test ItuRP2145.surfacetemperatureannual(lls..., p) == ItuRP2145.surfacetemperatureannual(ll, p)
+    @test ItuRP2145.surfacewatervapourdensityannual(lls..., p) == ItuRP2145.surfacewatervapourdensityannual(ll, p)
+    @test ItuRP2145.surfacepressureannual(lls..., p) == ItuRP2145.surfacepressureannual(ll, p)
+    @test ItuRP2145.surfacewatervapourcontentannual(lls..., p) == ItuRP2145.surfacewatervapourcontentannual(ll, p)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,8 +30,4 @@ end
     include("iturP838test.jl")
 end
 
-@testitem "P.839-4 - Rain Height Model" begin
-    include("iturP839test.jl")
-end
-
 @run_package_tests verbose=true


### PR DESCRIPTION
This MR refactors the code in P839 to use a specific artifact and the interpolators from the `ItuRP1144` module.

It also update the tests to directly extract testdata from the ITU Excel file (version 8.3). The actual values of the testdata is unchanged, but this clarifies the source of the data better.

As part of this MR, for all public methods accepting a latlon object as first argument (except from 618), we re-added methods to support providing lat and lon separately as first two arguments