### PR TITLE
refactor module ItuRP837 and update tests

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -33,6 +33,13 @@ git-tree-sha1 = "a21d87acc281d70dc82ff050ad23a39e60af962b"
     sha256 = "b8e9de886d893deb902d6bd4f137d18bc74cadaa1587af61a573b0947d5ff85d"
     url = "https://github.com/JuliaSatcomFramework/ItuRPropagation.jl/releases/download/artifact_releases/p676_data.tar.gz"
 
+[p837_R001]
+git-tree-sha1 = "af135bfd08b153149d8a141fceac2783930c40f0"
+
+    [[p837_R001.download]]
+    sha256 = "771ca7196c7bbca924c67a94b5f428e7de4c9256464554b7277063eeb79e0096"
+    url = "https://github.com/JuliaSatcomFramework/ItuRPropagation.jl/releases/download/artifact_releases/p837_R001.tar.gz"
+
 [p839]
 git-tree-sha1 = "2f4c1f82dc8fd5affa973a0dd272555b65c8f1eb"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Note that basically all changes above are **BREAKING**
 - The `ItuRP840.cloudattenuation` now has a different signature, with the elevation and exceedance probability swapped to e more consistent with the recent changes to other module.
 - Refactored the `ItuRP453` module to use independent artifacts and now provide a function to interpolate the wetterm refractive index not only at the 50 percentile
 - Refactored the `ItuRP839` module to use specific artifacts and its test to use the ITU validation excel version 8.3
+- Refactored the `ItuRP837` module to use specific artifacts and its test to use the ITU validation excel version 8.3
 
 ### Added
 - A new `ItuRP1144` module has been added to hold the interpolation functions defined recommendation ITU-R P.1144-12.

--- a/test/iturP837test.jl
+++ b/test/iturP837test.jl
@@ -1,109 +1,15 @@
-using DelimitedFiles
-using Test
-using ItuRPropagation
-
-struct TestData
-    testinput
-    answer
-end
-
-
-function testIturP837InterpolatedRandom()
-    allowableerror = 1.0e-7
-    randomdata = [
-        TestData(LatLon(-24.031250, 125.843750), 32.639062500),
-        TestData(LatLon(-48.656250, 119.843750), 25.529187500),
-        TestData(LatLon(-78.031250, -108.406250), 2.355062500),
-        TestData(LatLon(84.968750, 164.093750), 6.351500000),
-        TestData(LatLon(78.968750, -130.156250), 6.345687500),
-        TestData(LatLon(-23.031250, -37.656250), 68.605500000),
-        TestData(LatLon(31.718750, 179.593750), 52.349875000),
-        TestData(LatLon(29.843750, -156.531250), 48.476125000),
-        TestData(LatLon(89.468750, 29.593750), 6.066000000),
-        TestData(LatLon(-80.281250, 156.593750), 0.212437500),
-        TestData(LatLon(-4.531250, -131.281250), 63.658375000),
-        TestData(LatLon(-86.531250, -0.781250), 0.000000000),
-        TestData(LatLon(-2.531250, -52.406250), 90.853500000),
-        TestData(LatLon(47.843750, -149.406250), 30.150250000),
-        TestData(LatLon(-39.781250, -165.281250), 37.479125000),
-        TestData(LatLon(34.468750, 100.218750), 16.715000000),
-        TestData(LatLon(-69.156250, 7.468750), 5.873937500),
-        TestData(LatLon(35.593750, 27.468750), 33.499375000),
-        TestData(LatLon(-40.781250, -83.781250), 30.523937500),
-        TestData(LatLon(70.593750, -169.656250), 9.167250000),
-        TestData(LatLon(68.218750, 40.468750), 15.100062500),
-        TestData(LatLon(67.218750, -21.281250), 16.939375000),
-        TestData(LatLon(-28.406250, 110.468750), 25.379062500),
-        TestData(LatLon(-19.781250, 98.343750), 33.889750000),
-        TestData(LatLon(26.343750, 145.218750), 68.686500000),
-        TestData(LatLon(-81.406250, -134.406250), 1.271687500),
-        TestData(LatLon(33.718750, 76.093750), 14.926500000),
-        TestData(LatLon(-36.781250, 62.843750), 37.593625000),
-        TestData(LatLon(85.468750, 125.093750), 6.556312500),
-        TestData(LatLon(-51.531250, -72.531250), 14.977625000),]
-    errors = []
-    println(" ")
-    @testset "iturP837 (Itu-R P.837-7) annual rainfall rate exceeded 0.01%: random test" begin
-        for testdata in randomdata
-            error = abs(ItuRP837.rainfallrate001(testdata.testinput) - (testdata.answer))
-            push!(errors, error)
-            @test error < allowableerror
+@testitem "P.837-7 - Characteristics of precipitation for propagation modelling" setup = [setup_common] begin
+    entries = XLSX.openxlsx(validation_file) do wb
+        sheet = XLSX.getsheet(wb, "P.837-7 Rp")
+        map(eachrow(sheet["C69:F76"])) do row
+            (;
+                ll=LatLon(row[1], row[2]),
+                Rp=row[4],
+            )
         end
     end
-    println("MAX ERROR: $(maximum(errors)) mm/hr\n")
-end
-
-function testIturP837ituR001data()
-    allowableerror = 1.0e-3
-    errors = []
-    ituannualdata = [
-        TestData(LatLon(3.1330, 101.7000), 99.1481136),
-        TestData(LatLon(22.9000, -43.2300), 50.639304),
-        TestData(LatLon(23.0000, 30.0000), 0.0000000000),
-        TestData(LatLon(25.7800, -80.2200), 78.2982928),
-        TestData(LatLon(28.7170, 77.3000), 63.5972463999999),
-        TestData(LatLon(33.9400, 18.4300), 27.1349664),
-        TestData(LatLon(41.9000, 12.4900), 33.936232),
-        TestData(LatLon(51.5000, -0.1400), 26.48052),]
-    @testset "iturP837 (Itu-R P.837-7) annual rainfall rate exceeded 0.01%: ITU data test" begin
-        for testdata in ituannualdata
-            predictedvalue = ItuRP837.rainfallrate001(testdata.testinput)
-            error = abs(predictedvalue - testdata.answer)
-            push!(errors, error)
-            @test error < allowableerror
-        end
+    for entry in entries
+        (; ll, Rp) = entry
+        @test ItuRP837.rainfallrate001(ll) ≈ Rp rtol = error_tolerance
     end
-    println("MAX ERROR: $(maximum(errors)) mm/hr\n")
 end
-
-function testIturP837itufullmethoddata()
-    allowableerror = 1.0e-1
-    errors = []
-    ituannualdata = [
-        TestData(LatLon(3.1330, 101.7000), 99.1511718600),
-        TestData(LatLon(22.9000, -43.2300), 50.6393040000),
-        TestData(LatLon(23.0000, 30.0000), 0.0000000000),
-        TestData(LatLon(25.7800, -80.2200), 78.2994993000),
-        TestData(LatLon(28.7170, 77.3000), 63.6188880800),
-        TestData(LatLon(33.9400, 18.4300), 27.1358683200),
-        TestData(LatLon(41.9000, 12.4900), 33.9362320000),
-        TestData(LatLon(51.5000, -0.1400), 26.4805200000),]
-    @testset "iturP837 (Itu-R P.837-7) annual rainfall rate exceeded 0.01%: ITU data test" begin
-        for testdata in ituannualdata
-            predictedvalue = ItuRP837.rainfallrate001(testdata.testinput)
-            error = abs(predictedvalue - testdata.answer)
-            push!(errors, error)
-            @test error < allowableerror
-        end
-    end
-    println("MAX ERROR: $(maximum(errors)) mm/hr\n")
-end
-
-
-
-
-println("\n<===== " * "ITUR P837.7 "^5 * " =====")
-testIturP837InterpolatedRandom()
-testIturP837ituR001data()
-testIturP837itufullmethoddata()
-println("===== " * "ITUR P837.7 "^5 * "=====> \n")

--- a/test/iturP840test.jl
+++ b/test/iturP840test.jl
@@ -42,7 +42,7 @@ end
         map(eachrow(sheet["C24:G59"])) do row
             (;
                 ll=LatLon(row[1], row[2]),
-                p=row[3],
+                p=row[3],   
                 L=row[5],
             )
         end

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -48,6 +48,9 @@ end
     ###### P676 ######
     @test ItuRP676.gaseousattenuation(lls..., f, el, p) == ItuRP676.gaseousattenuation(ll, f, el, p)
 
+    ###### P837 ######
+    @test ItuRP837.rainfallrate001(lls...) == ItuRP837.rainfallrate001(ll)
+
     ###### P839 ######
     @test ItuRP839.isothermheight(lls...) == ItuRP839.isothermheight(ll)
     @test ItuRP839.rainheightannual(lls...) == ItuRP839.rainheightannual(ll)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,10 +22,6 @@ end
     include("iturP835test.jl")
 end
 
-@testitem "P.837-7 - Characteristics of precipitation for propagation modelling" begin
-    include("iturP837test.jl")
-end
-
 @testitem "P.838-3 - Specific attenuation model for rain for use in prediction methods" begin
     include("iturP838test.jl")
 end


### PR DESCRIPTION
This MR Refactors the `ItuRP837` module to use a specific artifact and update tests to read directly from the ITU validation excel version 8.3 (Test values did not change from previous version)