### PR TITLE
Small improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Note that basically all changes above are **BREAKING**
 - Refactored the `ItuRP453` module to use independent artifacts and now provide a function to interpolate the wetterm refractive index not only at the 50 percentile
 - Refactored the `ItuRP839` module to use specific artifacts and its test to use the ITU validation excel version 8.3
 - Refactored the `ItuRP837` module to use specific artifacts and its test to use the ITU validation excel version 8.3
+- The `attenuations` function is now defined inside the `ItuRP618` module but it's still exported by the main package module
+- The `LatLon` constructor now wraps the longitude instead of throwing for large values.
 
 ### Added
 - A new `ItuRP1144` module has been added to hold the interpolation functions defined recommendation ITU-R P.1144-12.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ Note that basically all changes above are **BREAKING**
   - The module now also supports computing the total barometric pressure and the integrated water vapour content, available via the `surfacepressureannual` and `surfacewatervapourcontentannual` functions, respectively.
 - The function of the `ItuRP2145` module are now tested against the validation examples excel provided by ITU-R.
 - Added a constant `SUPPRESS_WARNINGS::Ref{Bool}` in the main module that can be used to suppress warnings given by the various functions (Defaults to `false`)
+- It is now possible to add support for custom location types for all public functions of `ItuRPropagation` by:
+  - Defining a method for `Base.convert(::Type{LatLon}, custom_location::T)` which translates the `custom_location` to the equivalent `LatLon` object
+  - Optionally define a custom method for `ItuRPropagation.altitude_from_location(custom_location::T)` which returns the altitude of the location **in km** if this information is stored in the type of `custom_location`.
 
 ### Removed
 - The `ItuRP618.raindiversitygain`  and `ItuRP618.crosspolarizationdiscrimination` functions were removed as they are not being used

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Coverage](https://codecov.io/gh/disberd/ItuRPropagation.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/disberd/ItuRPropagation.jl)
 [![Aqua QA](https://raw.githubusercontent.com/JuliaTesting/Aqua.jl/master/badge.svg)](https://github.com/JuliaTesting/Aqua.jl)
 
-A Julia implementation of the ITU-Recommendations for space links covering cloud, gaseous, rain, and scintillation attenuations.
+A Julia implementation of some of the ITU-Recommendations for space links covering cloud, gaseous, rain, and scintillation attenuations.
 
 > [!NOTE]
 > This is a fork of the original repository aimed at adding some functionality and reducing allocations to speed up the computations. This version will be for the time being increased in version and tracked on a private registry for internal use. Inclusion of the changes in this repo to the upstream repository will be done if the original author @HillaryKChao agrees.
@@ -23,28 +23,18 @@ using ItuRPropagation
 ```
 
 ## ITU-R Recommendations
-The following ITU-R Recommendations are implemented:
-### Cloud Attenuation
-*   **ITU-R P.840-8:** Attenuation due to clouds and fog 
-### Gaseous Attenuation
-*   **ITU-R P.676-13:** Attenuation by atmospheric gases
+The following ITU-R Recommendations are implemented at least in part:
 *   **ITU-R P.453-14:** The radio refractive index: its formula and refractivity data
-*   **ITU-R P.835-16:** Reference Standard Atmospheres
-*   **ITU-R P.1511-2:** Topography for Earth-to-space propagation modelling
-*   **ITU-R P.2145-0:** Digital maps related to the calculation of gaseous attenuation and related effects
-### Rain Attenuation
-*   **ITU-R P.618-13:** Propagation data and prediction methods required for the design of Earth-space telecommunication systems
+*   **ITU-R P.618-14:** Propagation data and prediction methods required for the design of Earth-space telecommunication systems
+*   **ITU-R P.676-13:** Attenuation by atmospheric gases
+*   **ITU-R P.835-7:** Reference Standard Atmospheres
 *   **ITU-R P.837-7:** Characteristics of precipitation for propagation modelling
 *   **ITU-R P.838-8:** Specific attenuation model for rain for use in prediction methods
 *   **ITU-R P.839-4:** Rain height model for prediction methods.
-*   **ITU-R P.1511-2:** Topography for Earth-to-space propagation modelling
-### Scintillation Attenuation
-*   **ITU-R P.618-13:** Propagation data and prediction methods required for the design of Earth-space telecommunication systems
-*   **ITU-R P.453-14:** The radio refractive index: its formula and refractivity data
-
-### Noise temperature
-*   **ITU-R P.372-16:** Radio noise (only for earth stations - for space stations, a different estimate was used)
+*   **ITU-R P.840-9:** Attenuation due to clouds and fog 
+*   **ITU-R P.1144-12** Interpolations methods for other ITU-R Recommendations
+*   **ITU-R P.1511-3:** Topography for Earth-to-space propagation modelling
 *   **ITU-R P.2145-0:** Digital maps related to the calculation of gaseous attenuation and related effects
 
 ##  Validation
-This implementation has been validated using the [ITU Validation examples (rev 7.0.5)](https://www.itu.int/en/ITU-R/study-groups/rsg3/ionotropospheric/CG-3M3J-13-ValEx-Rev7.0.5.xlsx).
+This implementation has been validated using the [ITU Validation examples (rev 8.3.0)](https://www.itu.int/en/ITU-R/study-groups/rsg3/ionotropospheric/CG-3M3J-13-ValEx-Rev8.3.0.xlsx).

--- a/src/iturP1144.jl
+++ b/src/iturP1144.jl
@@ -2,7 +2,7 @@ module ItuRP1144
 
 export bilinear_interpolation
 
-using ..ItuRPropagation: ItuRPropagation, LatLon, ItuRVersion, _tolatlon
+using ..ItuRPropagation: ItuRPropagation, LatLon, ItuRVersion, tolatlon
 
 const version = ItuRVersion("ITU-R", "P.1144", 12, "(08/2023)")
 

--- a/src/iturP1511.jl
+++ b/src/iturP1511.jl
@@ -5,7 +5,7 @@ This Recommendation provides global topographical data, information on geographi
 height data for the prediction of propagation effects for Earth-space paths in ITU-R recommendations.
 =#
 
-using ..ItuRPropagation
+using ..ItuRPropagation: ItuRPropagation, LatLon, ItuRVersion, tolatlon, _tokm, ItuRP1144
 using Artifacts
 const version = ItuRVersion("ITU-R", "P.1511", 3, "(08/2023)")
 
@@ -48,7 +48,8 @@ Calculates topographic height as per Section 1.1 of ITU-R P.1511-3.
 # Return
 - `I::Real`: height (km)
 """
-function topographicheight(latlon::LatLon)
+function topographicheight(latlon)
+    latlon = tolatlon(latlon)
     grid_data = GRID_DATA.topo
     alt = ItuRP1144.bicubic_interpolation(grid_data.data, latlon, grid_data.latrange, grid_data.lonrange) / 1e3
     return alt

--- a/src/iturP2145.jl
+++ b/src/iturP2145.jl
@@ -6,7 +6,7 @@ temperature, surface water vapour density and integrated water vapour content re
 gaseous attenuation and related effects on terrestrial and Earth-space paths.
 =#
 
-using ..ItuRPropagation: ItuRPropagation, LatLon, ItuRVersion, ItuRP1511, ItuRP1144, tolatlon, _tokm, SUPPRESS_WARNINGS
+using ..ItuRPropagation: ItuRPropagation, LatLon, ItuRVersion, ItuRP1511, ItuRP1144, tolatlon, _tokm, SUPPRESS_WARNINGS, altitude_from_location
 using Artifacts: Artifacts, @artifact_str
 
 # Exports and constructor with separate latitude and longitude arguments
@@ -127,14 +127,14 @@ end
 @inline itp_inputs(p::Real; warn, kind) = ItuRP1144.ccdf_itp_inputs(p, psannual; warn, kind)
 
 function (nt::SingleVariableData)(latlon; alt = nothing)
+    alt = @something(alt, altitude_from_location(latlon)) |> _tokm
     latlon = tolatlon(latlon)
-    alt = @something(alt, ItuRP1511.topographicheight(latlon)) |> _tokm
     (; idxs, δr, δc) = itp_inputs(latlon)
     bilinear_interpolation(nt.mean, nt.scale, nt.Z_ground, nt.scale_func, idxs, δr, δc; alt)
 end
 function (nt::SingleVariableData)(latlon, p::Real; alt = nothing, warn = !SUPPRESS_WARNINGS[])
+    alt = @something(alt, altitude_from_location(latlon)) |> _tokm
     latlon = tolatlon(latlon)
-    alt = @something(alt, ItuRP1511.topographicheight(latlon)) |> _tokm
     (; idxs, δr, δc) = itp_inputs(latlon)
     (; pindexabove, pindexbelow) = itp_inputs(p; warn, kind = warnmsg_kind(nt))
     
@@ -288,8 +288,8 @@ The function can be called with the outage probability `p` as second positional 
 It also compute the altitude of the provided location if provided as nothing as kwarg
 """
 function annual_surface_values(latlon, args...; alt = nothing)
+    alt = @something(alt, altitude_from_location(latlon)) |> _tokm
     latlon = tolatlon(latlon)
-    alt = @something(alt, ItuRP1511.topographicheight(latlon)) |> _tokm
     P = surfacepressureannual(latlon, args...; alt)
     T = surfacetemperatureannual(latlon, args...; alt)
     ρ = surfacewatervapourdensityannual(latlon, args...; alt)

--- a/src/iturP2145.jl
+++ b/src/iturP2145.jl
@@ -6,7 +6,7 @@ temperature, surface water vapour density and integrated water vapour content re
 gaseous attenuation and related effects on terrestrial and Earth-space paths.
 =#
 
-using ..ItuRPropagation: ItuRPropagation, LatLon, ItuRVersion, ItuRP1511, ItuRP1144, _tolatlon, _tokm, SUPPRESS_WARNINGS
+using ..ItuRPropagation: ItuRPropagation, LatLon, ItuRVersion, ItuRP1511, ItuRP1144, tolatlon, _tokm, SUPPRESS_WARNINGS
 using Artifacts: Artifacts, @artifact_str
 
 # Exports and constructor with separate latitude and longitude arguments
@@ -127,13 +127,13 @@ end
 @inline itp_inputs(p::Real; warn, kind) = ItuRP1144.ccdf_itp_inputs(p, psannual; warn, kind)
 
 function (nt::SingleVariableData)(latlon; alt = nothing)
-    latlon = _tolatlon(latlon)
+    latlon = tolatlon(latlon)
     alt = @something(alt, ItuRP1511.topographicheight(latlon)) |> _tokm
     (; idxs, δr, δc) = itp_inputs(latlon)
     bilinear_interpolation(nt.mean, nt.scale, nt.Z_ground, nt.scale_func, idxs, δr, δc; alt)
 end
 function (nt::SingleVariableData)(latlon, p::Real; alt = nothing, warn = !SUPPRESS_WARNINGS[])
-    latlon = _tolatlon(latlon)
+    latlon = tolatlon(latlon)
     alt = @something(alt, ItuRP1511.topographicheight(latlon)) |> _tokm
     (; idxs, δr, δc) = itp_inputs(latlon)
     (; pindexabove, pindexbelow) = itp_inputs(p; warn, kind = warnmsg_kind(nt))
@@ -288,7 +288,7 @@ The function can be called with the outage probability `p` as second positional 
 It also compute the altitude of the provided location if provided as nothing as kwarg
 """
 function annual_surface_values(latlon, args...; alt = nothing)
-    latlon = _tolatlon(latlon)
+    latlon = tolatlon(latlon)
     alt = @something(alt, ItuRP1511.topographicheight(latlon)) |> _tokm
     P = surfacepressureannual(latlon, args...; alt)
     T = surfacetemperatureannual(latlon, args...; alt)

--- a/src/iturP2145.jl
+++ b/src/iturP2145.jl
@@ -10,7 +10,7 @@ using ..ItuRPropagation: ItuRPropagation, LatLon, ItuRVersion, ItuRP1511, ItuRP1
 using Artifacts: Artifacts, @artifact_str
 
 # Exports and constructor with separate latitude and longitude arguments
-for name in (:surfacetemperatureannual, :surfacewatervapourdensityannual, :surfacepressureannual, :surfacewatervapourcontentannual)
+for name in (:surfacetemperatureannual, :surfacewatervapourdensityannual, :surfacepressureannual, :surfacewatervapourcontentannual, :annual_surface_values)
     @eval $name(lat::Number, lon::Number, args...; kwargs...) = $name(LatLon(lat, lon), args...; kwargs...)
     @eval export $name
 end
@@ -276,7 +276,7 @@ surfacewatervapourcontentannual(args...; kwargs...) = getvariable(Val(:V))(args.
 
 
 """
-    _annual_surface_values(latlon[, p]; alt = nothing)
+    annual_surface_values(latlon[, p]; alt = nothing)
 
 This function is used to provide the annual surface values for variables refrenced in P676 and P618:
 - `P`: The total barometric pressure
@@ -287,8 +287,9 @@ The function can be called with the outage probability `p` as second positional 
 
 It also compute the altitude of the provided location if provided as nothing as kwarg
 """
-function _annual_surface_values(latlon, args...; alt = nothing)
-    alt = @something(alt, ItuRP1511.topographicheight(latlon))
+function annual_surface_values(latlon, args...; alt = nothing)
+    latlon = _tolatlon(latlon)
+    alt = @something(alt, ItuRP1511.topographicheight(latlon)) |> _tokm
     P = surfacepressureannual(latlon, args...; alt)
     T = surfacetemperatureannual(latlon, args...; alt)
     ρ = surfacewatervapourdensityannual(latlon, args...; alt)

--- a/src/iturP453.jl
+++ b/src/iturP453.jl
@@ -61,7 +61,7 @@ end
 #endregion initialization
 
 """
-    radiorefractiveindex(Pd::Real, T::Real, e::Real)
+    radiorefractiveindex(T::Real, Pd::Real, e::Real)
 
 Compute the atmospheric radio refractive index \$\\sqrt[n]{1 + x + x^2 + \\ldots}\$ based on Section 1.
 
@@ -87,7 +87,7 @@ end
 
 
 """
-    drytermradiorefractivity(Pd, T)
+    drytermradiorefractivity(T, Pd)
 
 Compute the dry term of the radio refractivity based on Section 1.
 
@@ -108,7 +108,7 @@ end
 
 
 """
-    wettermradiorefractivity(Pd::Real, T::Real)
+    wettermradiorefractivity(T, e)
 
 Compute the wet term of the radio refractivity based on Section 1.
 
@@ -144,6 +144,7 @@ function wettermsurfacerefractivityannual(latlon, p; warn=!SUPPRESS_WARNINGS[])
         initialize!()
         NWET_ANNUAL.ccdf
     end)::SquareGridStatisticalData{SGD_TYPE}
+    latlon = _tolatlon(latlon)
     return itp(latlon, p; warn, kind="the wet term of surface refractivity")
 end
 
@@ -157,6 +158,7 @@ function wettermsurfacerefractivityannual_50(latlon)
         initialize!()
         NWET_ANNUAL.ccdf
     end)::SquareGridStatisticalData{SGD_TYPE}
+    latlon = _tolatlon(latlon)
     itp =  ccdf.items[12] # index 12 is the one corresponding to 50% exceedance probability
     return itp(latlon)
 end

--- a/src/iturP453.jl
+++ b/src/iturP453.jl
@@ -7,7 +7,7 @@ Recommendation ITU-R P.453 provides methods to estimate the radio refractive ind
  parameters and their statistical variation.
 =#
 
-using ..ItuRPropagation: ItuRPropagation, LatLon, ItuRVersion, _tolatlon, _tokm, IturEnum, EnumWater, EnumIce, SUPPRESS_WARNINGS
+using ..ItuRPropagation: ItuRPropagation, LatLon, ItuRVersion, tolatlon, _tokm, IturEnum, EnumWater, EnumIce, SUPPRESS_WARNINGS
 using ..ItuRP1144: ItuRP1144, AbstractSquareGridITP, SquareGridData, SquareGridStatisticalData
 using Artifacts
 const version = ItuRVersion("ITU-R", "P.453", 14, "(08/2019)")
@@ -144,7 +144,7 @@ function wettermsurfacerefractivityannual(latlon, p; warn=!SUPPRESS_WARNINGS[])
         initialize!()
         NWET_ANNUAL.ccdf
     end)::SquareGridStatisticalData{SGD_TYPE}
-    latlon = _tolatlon(latlon)
+    latlon = tolatlon(latlon)
     return itp(latlon, p; warn, kind="the wet term of surface refractivity")
 end
 
@@ -158,7 +158,7 @@ function wettermsurfacerefractivityannual_50(latlon)
         initialize!()
         NWET_ANNUAL.ccdf
     end)::SquareGridStatisticalData{SGD_TYPE}
-    latlon = _tolatlon(latlon)
+    latlon = tolatlon(latlon)
     itp =  ccdf.items[12] # index 12 is the one corresponding to 50% exceedance probability
     return itp(latlon)
 end

--- a/src/iturP618.jl
+++ b/src/iturP618.jl
@@ -5,7 +5,7 @@ This Recommendation predicts the various propagation parameters needed in planni
 systems operating in either the Earth-to-space or space-to-Earth direction.
 =#
 
-using ..ItuRPropagation: ItuRPropagation, LatLon, ItuRVersion, _tolatlon, _tokm, _todeg, _toghz, SUPPRESS_WARNINGS, IturEnum, tilt_from_polarization, _validel, ItuRP840, ItuRP676, ItuRP453, ItuRP838, ItuRP837, ItuRP1511, ItuRP839, EnumCircularPolarization
+using ..ItuRPropagation: ItuRPropagation, LatLon, ItuRVersion, tolatlon, _tokm, _todeg, _toghz, SUPPRESS_WARNINGS, IturEnum, tilt_from_polarization, _validel, ItuRP840, ItuRP676, ItuRP453, ItuRP838, ItuRP837, ItuRP1511, ItuRP839, EnumCircularPolarization
 using Artifacts
 
 const version = ItuRVersion("ITU-R", "P.618", 14, "(08/2023)")
@@ -47,7 +47,7 @@ function scintillationattenuation(
     warn=!SUPPRESS_WARNINGS[],
 )
     # Input preprocessing
-    latlon = _tolatlon(latlon)
+    latlon = tolatlon(latlon)
     f = _toghz(f)
     el = _todeg(el)
     
@@ -142,7 +142,7 @@ function rainattenuation(
     warn=!SUPPRESS_WARNINGS[],
 )
     # Inputs Processing
-    latlon = _tolatlon(latlon)
+    latlon = tolatlon(latlon)
     el = _todeg(el)
     f = _toghz(f)
 
@@ -305,7 +305,7 @@ function attenuations(
     hᵣ = nothing,
     gamma_oxygen = nothing, γₒ = nothing,
 ) where {full_output}
-    latlon = _tolatlon(latlon)
+    latlon = tolatlon(latlon)
     el = _todeg(el)
     f = _toghz(f)
     _validel(el) # Validate input elevation

--- a/src/iturP618.jl
+++ b/src/iturP618.jl
@@ -46,6 +46,11 @@ function scintillationattenuation(
     efficiency = 60, η=efficiency,
     warn=!SUPPRESS_WARNINGS[],
 )
+    # Input preprocessing
+    latlon = _tolatlon(latlon)
+    f = _toghz(f)
+    el = _todeg(el)
+    
     (; As) = _scintillationattenuation(latlon, f, el, p; D, η, warn)
     return As
 end
@@ -242,12 +247,17 @@ function attenuations(
     polarization::IturEnum=EnumCircularPolarization,
     polarization_angle = tilt_from_polarization(polarization),
     warn=!SUPPRESS_WARNINGS[],
+    Ag_zenith = nothing,
+    Ac_zenith = nothing,
+    Nwet = nothing,
+    R001 = nothing,
+    hᵣ = nothing,
 )
     latlon = _tolatlon(latlon)
     el = _todeg(el)
     f = _toghz(f)
     _validel(el) # Validate input elevation
-    (; attenuations) = _attenuations(latlon, f, el, p; D, η, polarization_angle, alt, warn)
+    (; attenuations) = _attenuations(latlon, f, el, p; D, η, polarization_angle, alt, warn, Ag_zenith, Ac_zenith, Nwet, R001, hᵣ)
     return attenuations
 end
 

--- a/src/iturP676.jl
+++ b/src/iturP676.jl
@@ -562,9 +562,9 @@ function _slantoxygenattenuation(latlon::LatLon, f, el; γₒ, P, T, ρ)
     return (; Aₒ, Aₒ_zenith, γₒ, hₒ, aₒ, bₒ, cₒ, dₒ, P, T, ρ)
 end
 function _slantoxygenattenuation(latlon, f, el, p; γₒ=nothing, alt=nothing)
-    (; P, T, ρ, alt) = ItuRP2145._annual_surface_values(latlon, p; alt)
+    (; P, T, ρ, alt) = ItuRP2145.annual_surface_values(latlon, p; alt)
     γₒ = @something γₒ let
-        params = ItuRP2145._annual_surface_values(latlon; alt)
+        params = ItuRP2145.annual_surface_values(latlon; alt)
         P̄ = params.P
         T̄ = params.T
         ρ̄ = params.ρ
@@ -584,7 +584,7 @@ function _slantwaterattenuation(latlon, f, el; P, T, ρ, V)
     return (; Aᵥ, Aᵥ_zenith, Kᵥ, aᵥ, bᵥ, cᵥ, dᵥ, P, T, ρ, V)
 end
 function _slantwaterattenuation(latlon, f, el, p; alt=nothing)
-    (; P, T, ρ, alt) = ItuRP2145._annual_surface_values(latlon; alt)
+    (; P, T, ρ, alt) = ItuRP2145.annual_surface_values(latlon; alt)
     V = ItuRP2145.surfacewatervapourcontentannual(latlon, p; alt)
     _slantwaterattenuation(latlon, f, el; P, T, ρ, V)
 end

--- a/src/iturP676.jl
+++ b/src/iturP676.jl
@@ -591,7 +591,7 @@ end
 
 
 """
-    Ag = gaseousattenuation(latlon, f, el, p; alt = nothing)
+    Ag = gaseousattenuation(latlon, f, el, p; alt = nothing, gamma_oxygen = nothing, γₒ = nothing)
 
 Computes the statistical gaseous attenuation for a slant path following the approximate computation specified in Annex 2 of ITU-R P.676-13.
 
@@ -606,6 +606,7 @@ More specifically this computes ``Ag = Ao + Aw`` implementing:
 
 # Keyword arguments
 - `alt`: Altitude at the provided location, to be used for computing the various intermediate varaibles. If not provided, default to the altitude computed with `ItuRP1511.topographicheight`
+- `gamma_oxygen` (or `γₒ`): Specific attenuation due to oxygen (dB/km) computed from the average surface conditions, at the desired location. **This is computed automatically based on other inputs if not explicitly provided, but it is only location dependent and >70% of the time is spent in computing this, so consider precomputing and passing it directly for maximum speed**
 
 See the extended help for the signature of the function with precomputed intermediate variables.
 
@@ -630,7 +631,7 @@ This method do not accept the outage probability `p` as last argument but expect
 - `T`: Surface temperature (K) at the desired exceedance probability, at the desired location.
 - `rho`: Surface water vapour density (g/m^3) at the desired exceedance probability, at the desired location.
 - `V`: Surface water vapour content (kg/m^2) at the desired exceedance probability, at the desired location.
-- `gamma_oxygen` (or `γₒ`): Specific attenuation due to oxygen (dB/km) computed from the average surface conditions, at the desired location. **This is computed automatically based on other inputs if not explicitly provided**
+- `gamma_oxygen` (or `γₒ`): Specific attenuation due to oxygen (dB/km) computed from the average surface conditions, at the desired location. **This is computed automatically based on other inputs if not explicitly provided, but it is only location dependent and >70% of the time is spent in computing this, so consider precomputing and passing it directly for maximum speed**
 """
 function gaseousattenuation(latlon, f, el; 
     P_mean = nothing, P̄ = nothing, # Average surface total pressure at the desired location
@@ -659,15 +660,15 @@ function gaseousattenuation(latlon, f, el;
     return Agas
 end
 
-function gaseousattenuation(latlon, f, el, p; alt=nothing)
-    mean_vals = ItuRP2145._annual_surface_values(latlon; alt)
+function gaseousattenuation(latlon, f, el, p; alt=nothing, gamma_oxygen=nothing, γₒ=nothing)
+    mean_vals = ItuRP2145.annual_surface_values(latlon; alt)
     P̄ = mean_vals.P
     T̄ = mean_vals.T
     ρ̄ = mean_vals.ρ
     alt = mean_vals.alt
-    (; P, T, ρ) = ItuRP2145._annual_surface_values(latlon, p; alt)
+    (; P, T, ρ) = ItuRP2145.annual_surface_values(latlon, p; alt)
     V = ItuRP2145.surfacewatervapourcontentannual(latlon, p; alt)
-    gaseousattenuation(latlon, f, el; P̄, T̄, ρ̄, V, P, T, ρ)
+    gaseousattenuation(latlon, f, el; P̄, T̄, ρ̄, V, P, T, ρ, gamma_oxygen, γₒ)
 end
 
 end # module ItuRP676

--- a/src/iturP676.jl
+++ b/src/iturP676.jl
@@ -17,7 +17,7 @@ c) an approximate method in Annex 2 to estimate the statistics of slant path gas
 d) a Weibull approximation to the slant path water vapour attenuation for use in
     Recommendation ITU-R P.1853.
 
-The curren implementation only covers points a) and c) in the above list
+The current implementation only covers points a) and c) in the above list
 =#
 
 using ..ItuRPropagation: _todeg, ItuRP835, ItuRP453, ItuRVersion, ItuRP1511, LatLon, ItuRP2145, _toghz

--- a/src/iturP835.jl
+++ b/src/iturP835.jl
@@ -5,7 +5,7 @@ Recommendation ITU-R P.835 provides expressions and data for reference standard 
 the calculation of gaseous attenuation on Earth-space paths.
 =#
 
-using ..ItuRPropagation
+using ..ItuRPropagation: ItuRPropagation, LatLon, ItuRVersion, tolatlon, _tokm
 using Artifacts
 
 const version = ItuRVersion("ITU-R", "P.835", 7, "(08/2024)")
@@ -24,7 +24,8 @@ Standard temperature for geometric heights <= 100 km, based on equations 2a-2g a
 # Return
 - temperature (°K)
 """
-function standardtemperature(Z::Real)
+function standardtemperature(Z)
+    Z = _tokm(Z)
     0 ≤ Z ≤ 100 || throw(ArgumentError("Z=$Z\n (geometric height) in IturP835.standardtemperature must be between 0 and 100"))
 
     hp = geopotentialheight(Z)
@@ -51,17 +52,18 @@ end
 
 
 """
-    standardpressure(Z::Float64)
+    standardpressure(Z)
 
 Standard pressure for geometric heights <= 100 km, based on equations 3a-3g and 5 of Section 1.1.
 
 # Arguments
-- `Z::Float64`: geometric height (km)
+- `Z`: geometric height (km)
 
 # Return
 - dry pressure (hPa)
 """
-function standardpressure(Z::Real)
+function standardpressure(Z)
+    Z = _tokm(Z)
     0 ≤ Z ≤ 100 || throw(ArgumentError("Z=$Z\n (geometric height) in IturP835.standardpressure must be between 0 and 100"))
     hp = geopotentialheight(Z)
     if 0 <= hp <= 11
@@ -95,7 +97,7 @@ end
 Standard water vapour density for geometric heights <= 100 km, based on equations 6-8 of Section 1.2.
 
 # Arguments
-- `Z::Real`: geometric height (km)
+- `Z`: geometric height (km)
 
 # Keyword arguments
 - `rho_0::Real=7.5`: standard ground level water vapour density (g/m^3). Can also be provided as `ρ₀`.
@@ -103,12 +105,13 @@ Standard water vapour density for geometric heights <= 100 km, based on equation
 - `P::Real`: Total barometric pressure (hPa) at given height. Computed with `standardpressure(Z)` if not provided.
 """
 function standardwatervapourdensity(
-        Z::Real; 
+        Z; 
         rho_0 = nothing,
         ρ₀ = nothing,
         T = standardtemperature(Z),
         P = standardpressure(Z),
 )
+    Z = _tokm(Z)
     ρ₀ = @something ρ₀ rho_0 7.5
     # equation 6 where h₀ = 2; equation 7 where ρ₀=7.5
     ρ = ρ₀ * exp(-Z / 2)

--- a/src/iturP837.jl
+++ b/src/iturP837.jl
@@ -15,7 +15,7 @@ When reliable long-term local rainfall rate data is available with integration t
  times that exceed 1-min to rainfall rate statistics with a 1-min integration time.
 =#
 
-using ..ItuRPropagation: ItuRPropagation, LatLon, ItuRVersion, _tolatlon
+using ..ItuRPropagation: ItuRPropagation, LatLon, ItuRVersion, tolatlon
 using ..ItuRP1144: ItuRP1144, SquareGridData
 using Artifacts
 
@@ -68,7 +68,7 @@ Computes rainfall rate exceeded 0.01% via bi-linear interpolation as described i
 - `R::Float64`: annual rainfall rate exceeded 0.01%
 """
 function rainfallrate001(latlon)
-    latlon = _tolatlon(latlon)
+    latlon = tolatlon(latlon)
     itp = @something(R001_DATA.itp, let
         initialize!()
         R001_DATA.itp

--- a/src/iturP838.jl
+++ b/src/iturP838.jl
@@ -2,7 +2,7 @@ module ItuRP838
 
 #=
 Recommendation ITU-R P.838-3 recommends the procedure for obtaining the 
- specfic attenuation (gamma sub R in dB/km) from the rain rate R (mm/h).
+ specific attenuation (gamma sub R in dB/km) from the rain rate R (mm/h).
 =#
 
 using ..ItuRPropagation: ItuRPropagation, LatLon, ItuRVersion, _todeg, SUPPRESS_WARNINGS, tilt_from_polarization, IturEnum, _toghz, EnumCircularPolarization, _validel

--- a/src/iturP839.jl
+++ b/src/iturP839.jl
@@ -4,7 +4,7 @@ module ItuRP839
 This Recommendation provides a method to predict the rain height for propagation prediction.
 =#
 
-using ..ItuRPropagation: ItuRPropagation, LatLon, ItuRVersion, _tolatlon, _tokm, _toghz, SUPPRESS_WARNINGS
+using ..ItuRPropagation: ItuRPropagation, LatLon, ItuRVersion, tolatlon, _tokm, _toghz, SUPPRESS_WARNINGS
 using ..ItuRP1144: ItuRP1144, AbstractSquareGridITP, SquareGridData, SquareGridStatisticalData
 using Artifacts
 const version = ItuRVersion("ITU-R", "P.839", 4, "(09/2013)")
@@ -60,7 +60,7 @@ h0 will be interpolated for the given latitude and longitude.
 - `h0`: mean annual 0°C isotherm height (km) above mean sea level
 """
 function isothermheight(latlon)
-    latlon = _tolatlon(latlon)
+    latlon = tolatlon(latlon)
     return H0_DATA(latlon)
 end
 

--- a/src/iturP840.jl
+++ b/src/iturP840.jl
@@ -4,7 +4,7 @@ module ItuRP840
 This Recommendation provides methods to predict the attenuation due to clouds and fog on Earth-space paths.
 =#
 
-using ..ItuRPropagation: ItuRPropagation, LatLon, ItuRVersion, _tolatlon, _tokm, _todeg, _toghz, SUPPRESS_WARNINGS
+using ..ItuRPropagation: ItuRPropagation, LatLon, ItuRVersion, tolatlon, _tokm, _todeg, _toghz, SUPPRESS_WARNINGS
 using ..ItuRP1144: ItuRP1144, AbstractSquareGridITP, SquareGridData, SquareGridStatisticalData
 using Artifacts: Artifacts, @artifact_str
 
@@ -139,7 +139,7 @@ Computes the integrated liquid water content at a given location and exceedance 
 - `p`: exceedance probability (%)   
 """
 function liquidwatercontent(latlon, p; warn=!SUPPRESS_WARNINGS[])
-    latlon = _tolatlon(latlon)
+    latlon = tolatlon(latlon)
     itp = @something(ANNUAL_DATA.ccdf,let
         initialize!()
         ANNUAL_DATA.ccdf

--- a/src/iturP840.jl
+++ b/src/iturP840.jl
@@ -139,6 +139,7 @@ Computes the integrated liquid water content at a given location and exceedance 
 - `p`: exceedance probability (%)   
 """
 function liquidwatercontent(latlon, p; warn=!SUPPRESS_WARNINGS[])
+    latlon = _tolatlon(latlon)
     itp = @something(ANNUAL_DATA.ccdf,let
         initialize!()
         ANNUAL_DATA.ccdf
@@ -161,6 +162,7 @@ Computes annual cloud attenuation along a slant path based on Section 3.
 - `Acloud::Real`: slant path cloud attenuation (dB)
 """
 function cloudattenuation(latlon, f, el, p; warn=!SUPPRESS_WARNINGS[])
+    # We don't preprocess the latlon as that is only used in liquidwatercontent which already preprocess
     L = liquidwatercontent(latlon, p)
     return cloudattenuation(latlon, f, el; L, warn)
 end

--- a/src/iturcommon.jl
+++ b/src/iturcommon.jl
@@ -11,15 +11,8 @@ struct LatLon
     lat::Float64
     lon::Float64
     function LatLon(lat, lon)
-        if lat < -90.0 || lat > 90.0
-            throw(ErrorException("lat=$lat\nlat (latitude) should be between -90 and 90"))
-        end
-        if lon > 180
-            lon -= 360
-        end
-        if lon < -180 || lon > 180
-            throw(ErrorException("lon=$lon\nlon (longitude) should be between -180 and 180"))
-        end
+        -90 ≤ lat ≤ 90 || throw(ErrorException("lat=$lat\nlat (latitude) should be between -90 and 90"))
+        lon = rem(lon, 360, RoundNearest)
         new(lat, lon)
     end
 end

--- a/src/iturcommon.jl
+++ b/src/iturcommon.jl
@@ -26,7 +26,25 @@ end
 # We expects inputs in GHz
 @inline _toghz(val::Real) = val
 
-@inline _tolatlon(x) = convert(LatLon, x)::LatLon # Type assertion on convert is used to help compiler, see https://github.com/JuliaLang/julia/issues/42372 for more details
+"""
+    tolatlon(location)
+
+This function converts the location input to a `LatLon` object, by default by calling `convert(LatLon, location)`.
+
+Custom location types that want to implement the interface of ItuRPropagation should override the `ItuRPropagation.tolatlon` method to return a `LatLon` object, and optionally the `ItuRPropagation.altitude_from_location` method if they already store information about the location altitude.
+"""
+@inline tolatlon(x) = convert(LatLon, x)::LatLon # Type assertion on convert is used to help compiler, see https://github.com/JuliaLang/julia/issues/42372 for more details
+
+"""
+    altitude_from_location(location)
+
+This function tries to extract the altitude **(in km)** from the location input provided.
+
+It defaults to converting the location to `latlon` with `ItuRPropagation.tolatlon` and then calling `ItuRP1511.topographicheight` on it.
+
+Custom location types that want to implement the interface of ItuRPropagation should override the `ItuRPropagation.tolatlon` method, and optionally the `ItuRPropagation.altitude_from_location` method if they already store information about the location altitude.
+"""
+@inline altitude_from_location(location) = ItuRP1511.topographicheight(tolatlon(location))
 
 @inline _validel(el::Real) = (0 ≤ el ≤ 90) || @noinline(throw(ArgumentError("Elevation angles must be provided between 0 and 90 degrees.\nThe given elevation angle ($el degrees) is not a valid input.")))
 

--- a/src/iturcommon.jl
+++ b/src/iturcommon.jl
@@ -18,7 +18,7 @@ struct LatLon
             lon -= 360
         end
         if lon < -180 || lon > 180
-            throw(ErrorException("lon=$lat\nlon (longitude) should be between -180 and 180"))
+            throw(ErrorException("lon=$lon\nlon (longitude) should be between -180 and 180"))
         end
         new(lat, lon)
     end

--- a/test/iturP618test.jl
+++ b/test/iturP618test.jl
@@ -191,11 +191,11 @@ end
         p = rand() * 49.999 + .001
         latlon = LatLon(rand() * 180 - 90, rand() * 360 - 180)
         # Compute the stable kwargs for faster computation. Elevation is irrelevant here as we only need the zenith values which are contained in the `kwargs` field
-        (; kwargs) = ItuRP618._attenuations(latlon, f, rand() * 50 + 10, p; D)
+        (; kwargs) = ItuRP618.attenuations(latlon, f, rand() * 50 + 10, p, Val(true); D)
         for _ in 1:20
             el = rand() * 85 + 5 # Elevation is irrelevant here as we only need the zenith values
             out_standard = ItuRP618.attenuations(latlon, f, el, p; D)
-            out_fast = ItuRP618._attenuations(latlon, f, el, p; D, kwargs...).attenuations
+            out_fast = ItuRP618.attenuations(latlon, f, el, p; D, kwargs...)
             @test all(propertynames(out_standard)) do fld
                 isapprox(getproperty(out_standard, fld), getproperty(out_fast, fld))
             end

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -19,7 +19,9 @@
     @test_logs (:warn, r"between 4 and 55 GHz") match_mode=:any ItuRP618.scintillationattenuation(LatLon(0, 0), 1000, 30, 3)
     @test_logs (:warn, r"between 0.01% and 50%") match_mode=:any ItuRP618.scintillationattenuation(LatLon(0, 0), 30, 1, 0.001)
     @test_logs (:warn, r"between 5 and 90 degrees") match_mode=:any ItuRP618.scintillationattenuation(LatLon(0, 0), 30, 1, 1)
+    @test_logs (:warn, r"between 0 and 100") match_mode=:any ItuRP618.scintillationattenuation(LatLon(0, 0), 30, 20, 1; efficiency = .5)
     @test_throws ArgumentError ItuRP618.scintillationattenuation(LatLon(0, 0), 30, 100, 1)
+    @test_throws ArgumentError ItuRP618.scintillationattenuation(LatLon(0, 0), 30, 1, 1; efficiency = 101)
 
     # Total Attenuations, we just test that scintillation warn is not triggered when p < 0.01 but function is called through attenuations
     @test_logs ItuRP618.attenuations(LatLon(0, 0), 30, 10, 0.001; D = 1)
@@ -44,6 +46,7 @@
         @test_logs ItuRP618.scintillationattenuation(LatLon(0, 0), 1000, 30, 3)
         @test_logs ItuRP618.scintillationattenuation(LatLon(0, 0), 30, 1, 0.001)
         @test_logs ItuRP618.scintillationattenuation(LatLon(0, 0), 30, 1, 1)
+        @test_logs ItuRP618.scintillationattenuation(LatLon(0, 0), 30, 20, 1; efficiency = .5)
     finally
         ItuRPropagation.SUPPRESS_WARNINGS[] = false
     end

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -25,6 +25,7 @@
 
     # Total Attenuations, we just test that scintillation warn is not triggered when p < 0.01 but function is called through attenuations
     @test_logs ItuRP618.attenuations(LatLon(0, 0), 30, 10, 0.001; D = 1)
+    @test_throws "forgot to provide one argument" ItuRP618.attenuations(0, 0, 30, 10; D = 1)
 
     # Test suppression of warnings
     ItuRPropagation.SUPPRESS_WARNINGS[] = true
@@ -102,4 +103,25 @@ end
     @test ItuRP2145.surfacewatervapourdensityannual(lls..., p) == ItuRP2145.surfacewatervapourdensityannual(ll, p)
     @test ItuRP2145.surfacepressureannual(lls..., p) == ItuRP2145.surfacepressureannual(ll, p)
     @test ItuRP2145.surfacewatervapourcontentannual(lls..., p) == ItuRP2145.surfacewatervapourcontentannual(ll, p)
+end
+
+@testitem "Implement Interface" begin
+    # We create a custom struct that also stores location (in m) and lat/lon in radians
+    struct LLA
+        lat::Float64
+        lon::Float64
+        alt::Float64
+    end
+    lla = LLA(π/6, π/4, 1200)
+    Base.convert(::Type{LatLon}, lla::LLA) = LatLon(lla.lat |> rad2deg, lla.lon |> rad2deg)::LatLon
+    ItuRPropagation.altitude_from_location(lla::LLA) = lla.alt / 1e3
+
+    alt_1511 = ItuRP1511.topographicheight(lla)
+    @test ItuRPropagation.altitude_from_location(lla) != alt_1511
+
+    atts = ItuRP618.attenuations(lla, 30, 20, 1; D = 1)
+    bench_wrongalt = ItuRP618.attenuations(LatLon(30, 45), 30, 20, 1; D = 1)
+    bench_correctalt = ItuRP618.attenuations(lla, 30, 20, 1; D = 1, alt = 1.2)
+    @test atts.At ≉ bench_wrongalt.At
+    @test atts.At ≈ bench_correctalt.At
 end


### PR DESCRIPTION
This PR fixes some inconsistencies and improves package API in the following ways:
- It is now possible to speed up attenuations computations by providing precomputed inputs as keyword arguments.
  - It is also possible to extract computed intermediate results to use in subsequent calls by passing `Val(true)` as last argument of the `attenuations` function. Check the extended help of the functions for more details
- It is possible to allow custom location types (e.g. LatLon from CoordRefSystems.jl) to use the public functions of this package by:
  - Defining a method for `Base.convert(::Type{LatLon}, custom_location::T)` which translates the `custom_location` to the equivalent `LatLon` object
  - Optionally define a custom method for `ItuRPropagation.altitude_from_location(custom_location::T)` which returns the altitude of the location **in km** if this information is stored in the type of `custom_location` (as in LatLonAlt from CoordRefSystems.jl). 