### PR TITLE
add CoordRefSystems.jl as extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Note that basically all changes above are **BREAKING**
   - Values in `Hz` (or any frequency unit) for `f` inputs
   - Values in `m` (or any length unit) for any input expecting km (e.g. `alt`)
   - Values in `°` or `rad` for `lat` and `lon`
+- Added support for `LatLon` and `LatLonAlt` from `CoordRefSystems.jl` as inputs to the various functions of the package.
 
 ### Removed
 - The `ItuRP618.raindiversitygain`  and `ItuRP618.crosspolarizationdiscrimination` functions were removed as they are not being used

--- a/Project.toml
+++ b/Project.toml
@@ -9,11 +9,14 @@ Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 
 [weakdeps]
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+CoordRefSystems = "b46f11dc-f210-4604-bfba-323c1ec968cb"
 
 [extensions]
 UnitfulExt = "Unitful"
+CoordRefSystemsExt = "CoordRefSystems"
 
 [compat]
 Artifacts = "1"
+CoordRefSystems = "0.14 - 0.17"
 Unitful = "1.23.0"
 julia = "1.10"

--- a/ext/CoordRefSystemsExt.jl
+++ b/ext/CoordRefSystemsExt.jl
@@ -1,0 +1,12 @@
+module CoordRefSystemsExt
+
+using ItuRPropagation: ItuRPropagation, altitude_from_location, LatLon
+using CoordRefSystems: LatLonAlt, LatLon as CLL
+
+# Convert method
+Base.convert(::Type{LatLon}, location::Union{LatLonAlt, CLL}) = LatLon(location.lat, location.lon)
+
+# Altitude method for LatLonAlt
+ItuRPropagation.altitude_from_location(location::LatLonAlt) = location.alt
+
+end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+CoordRefSystems = "b46f11dc-f210-4604-bfba-323c1ec968cb"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"


### PR DESCRIPTION
This PR adds support for `LatLon` and `LatLonAlt` from `CoordRefSystems.jl` as inputs to the various functions of the package.